### PR TITLE
Camera: Handle duplicate camera Id due to openLegacy support. av: camera: Allow disabling shutter sound for specific packages

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -2088,8 +2088,25 @@ CameraService::Client::Client(const sp<CameraService>& cameraService,
     mRemoteCallback = cameraClient;
 
     cameraService->loadSound();
+    cameraService->ensureCameraShutterSoundDisabled(clientPackageName);
 
     LOG1("Client::Client X (pid %d, id %d)", callingPid, mCameraId);
+}
+
+void CameraService::ensureCameraShutterSoundDisabled(const String16& clientPackageName) {
+    char value[PROPERTY_VALUE_MAX];
+    if (property_get("camera.shutter_sound.blacklist", value, NULL) > 0){
+        std::stringstream disable_shutter_package_list(value);
+        std::string package;
+        while(std::getline(disable_shutter_package_list, package, ',')){
+            if (package.compare(String8(clientPackageName)) == 0){
+                mSoundPlayer[SOUND_SHUTTER] = NULL;
+                mSoundPlayer[SOUND_RECORDING_START] = NULL;
+                mSoundPlayer[SOUND_RECORDING_STOP] = NULL;
+                return;
+            }
+        }
+    }
 }
 
 // tear down the client

--- a/services/camera/libcameraservice/CameraService.h
+++ b/services/camera/libcameraservice/CameraService.h
@@ -178,6 +178,7 @@ public:
     };
 
     void                loadSound();
+    void                ensureCameraShutterSoundDisabled(const String16& clientPackageName);
     void                playSound(sound_kind kind);
     void                releaseSound();
 

--- a/services/camera/libcameraservice/common/CameraProviderManager.cpp
+++ b/services/camera/libcameraservice/common/CameraProviderManager.cpp
@@ -631,7 +631,12 @@ status_t CameraProviderManager::ProviderInfo::addDevice(const std::string& name,
 
     mUniqueCameraIds.insert(id);
     if (isAPI1Compatible) {
+        // addDevice can be called more than once for the same camera id if HAL
+        // supports openLegacy.
+        if (std::find(mUniqueAPI1CompatibleCameraIds.begin(), mUniqueAPI1CompatibleCameraIds.end(),
+                id) == mUniqueAPI1CompatibleCameraIds.end()) {
         mUniqueAPI1CompatibleCameraIds.push_back(id);
+        }
     }
 
     if (parsedId != nullptr) {


### PR DESCRIPTION
Camera: Handle duplicate camera Id due to openLegacy support

When HAL supports openLegacy, same camera id can be added more than
once.

Because we now use vector to store API1 compatible camera ids, make
sure no duplicate strings are added.

Test: Vendor camera app using openLegacy, Camera CTS
Bug: 110815837
Bug: 111963599


Some third-party cameras play back their shutter sound.
This produces a double sound. This patch fixes this problem.

camera.shutter_sound.blacklist=com.android.camera - allows
to disable the system shutter sound for a specific camera package.